### PR TITLE
feat: Adds LZ compression for obfuscated params, hiding input box when prefilled and temporary css

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <link rel="stylesheet" href="./src/index.css" />
+    <link rel="stylesheet" href="src/index.css" />
     <title>Julehilsen fra Variant</title>
 
-    <link rel="shortcut icon" href="./assets/favicon.png" type="image/png" />
+    <link rel="shortcut icon" href="assets/favicon.png" type="image/png" />
 
     <style>
       /* Document specific styling here */
@@ -28,7 +28,8 @@
     </main>
 
     <!-- Include variable injector script -->
-    <script src="./src/var-injector.js"></script>
+    <script src="https://unpkg.com/lz-string@1.4.4/libs/lz-string.min.js"></script>
+    <script src="src/var-injector.js"></script>
     <script>
       const card = document.querySelector(".card");
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,600");
+@import url("https://styleguide.variant.no/_next/static/css/4b5b62cde696cf7498c4.css");
 
 :root {
   --font-size-min: 10;
@@ -17,7 +17,7 @@
 }
 
 html {
-  font-family: "IBM Plex Sans", serif;
+  font-family: "Graphik Web", serif;
   font-size: calc(
     (var(--font-size-min) * 1px) + (var(--font-size-max) - var(--font-size-min)) *
       (
@@ -76,7 +76,7 @@ main {
   perspective: 1500px;
 }
 .page__first {
-  background-image: url(/assets/purple-first-front.svg);
+  background-image: url(../assets/purple-first-front.svg);
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -90,7 +90,7 @@ main {
 }
 .page__first::after {
   content: "";
-  background-image: url(/assets/purple-first-back.svg);
+  background-image: url(../assets/purple-first-back.svg);
   position: absolute;
   padding: 2rem;
   top: 0;
@@ -103,7 +103,7 @@ main {
   transition: all 0.3s 0.5s;
 }
 .page__second {
-  background-image: url(/assets/purple-second.svg);
+  background-image: url(../assets/purple-second.svg);
 
   width: 100%;
   height: 100%;

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url("https://styleguide.variant.no/_next/static/css/4b5b62cde696cf7498c4.css");
+@import url("https://styleguide.variant.no/_next/static/css/5feffe362c34ea575951.css");
 
 :root {
   --font-size-min: 10;

--- a/src/inject-style.css
+++ b/src/inject-style.css
@@ -3,6 +3,11 @@
   v-item {
     background: rgb(255, 255, 224, 0.5);
   }
+
+  .hiddenInput v-field,
+  .hiddenInput v-item {
+    background: transparent;
+  }
 }
 
 .var-injector {

--- a/src/var-injector.js
+++ b/src/var-injector.js
@@ -87,8 +87,10 @@ window.addEventListener("load", function () {
     top.classList.remove("var-injector--open");
   });
 
-  document.body.insertBefore(top, main);
-  updateUrlBox();
+  if (!location.search) {
+    document.body.insertBefore(top, main);
+    updateUrlBox();
+  }
 });
 
 function getLists() {

--- a/src/var-injector.js
+++ b/src/var-injector.js
@@ -437,7 +437,7 @@ function container(form) {
       },
       [
         img({
-          src: "/assets/edit.svg",
+          src: "assets/edit.svg",
           alt: title,
         }),
       ]
@@ -453,7 +453,7 @@ function insertCss() {
     link({
       type: "text/css",
       rel: "stylesheet",
-      href: "/src/inject-style.css",
+      href: "src/inject-style.css",
     })
   );
 }
@@ -490,7 +490,7 @@ function objectToUrl(obj) {
   for (let key of Object.keys(obj)) {
     params.set(key, obj[key]);
   }
-  return getUrl() + "?" + params.toString();
+  return getUrl() + encodeParams(params);
 }
 
 function getUrl() {
@@ -513,7 +513,7 @@ function toBoolean(val) {
 }
 
 function queryToObject() {
-  const params = new URLSearchParams(document.location.search);
+  const params = new URLSearchParams(decodeParams(document.location.search));
   let obj = {};
   for (let [key, val] of params) {
     const metadata = getPath(key);
@@ -588,4 +588,15 @@ function translateMonths(str) {
     lowerCase = lowerCase.replace(from, to);
   });
   return lowerCase;
+}
+
+function decodeParams(str) {
+  if (!str) {
+    return "";
+  }
+  return LZString.decompressFromEncodedURIComponent(str.slice(1));
+}
+function encodeParams(params) {
+  if (!params) return "";
+  return "?" + LZString.compressToEncodedURIComponent(params.toString());
 }

--- a/src/var-injector.js
+++ b/src/var-injector.js
@@ -90,6 +90,8 @@ window.addEventListener("load", function () {
   if (!location.search) {
     document.body.insertBefore(top, main);
     updateUrlBox();
+  } else {
+    document.body.classList.add("hiddenInput");
   }
 });
 


### PR DESCRIPTION
This PR does multiple things (😬 )

- Adds profile css directly from styleguide. Not the best way to be honest, as the hash would change on redeploy for the styleguide, but I think it may work for now.
- Hides input box when we have parameters. I did this instead of checking for a parameter directly as I feel this will suffice for Christmas card implementation
- Changes parameter type to be a compressed string that is more obfuscated than using form data directly. Not so pretty, but works well enough I think.

I've also added domain: https://julehilsen.variant.no


Check out demo of [this branch/PR here](https://julehilsen-2faocnhhi.vercel.app/?JYOwDgrgLgtFwBsC8BBAJgJ2AQxAMlElgAtEBnAUxCQHEB7NAagCsIFGBrZgUgGEBmbigBsGCpzoIEFAObZuAJgCMBcNBgAzDNiQBZYB2wUEQA)